### PR TITLE
Fix tag comparison (numerical order)

### DIFF
--- a/src/git_conventional_version/versioning/releases.py
+++ b/src/git_conventional_version/versioning/releases.py
@@ -47,7 +47,7 @@ class Release:
     def _sort_version_strings(self, version_strings: List[str]) -> List[str]:
         return sorted(
             version_strings,
-            key=lambda x: tuple(re.findall(r'\d+', x)),
+            key=lambda x: tuple([int(i) for i in re.findall(r'\d+', x)]),
             reverse=True
         )
 


### PR DESCRIPTION
Tag comparison was done using alphabetical ordering instead of numerical ordering.
This won't work for releases that uses numbers over 9.
Casting each version component to an int will force numerical ordering.

The bug can easily be reproduced by creating a dummy repository and adding tags "0.9.0" and "0.10.0".
"0.9.0"will be seen as the latest by error.